### PR TITLE
Add frontend for system status

### DIFF
--- a/src/io/SystemMetadata.tsx
+++ b/src/io/SystemMetadata.tsx
@@ -10,16 +10,21 @@ export interface SystemMetadata {
 export class SystemMetadataUtils {
 
     public static memoryStringFormat(numberToFormat: number) {
-        // number of bytes in a terabyte, gigabyte, and megabyte.
+        const BYTES_IN_KILOBYTE: number = 1000;
+        const BYTES_IN_MEGABYTE: number = BYTES_IN_KILOBYTE * 1000;
+        const BYTES_IN_GIGABYTE: number = BYTES_IN_MEGABYTE * 1000;
+        const BYTES_IN_TERABYTE: number = BYTES_IN_GIGABYTE * 1000;
         let result: string;
-        if (numberToFormat >= 1099511627776) {
-            result = (numberToFormat / 1099511627776).toPrecision(4).toString()  + "TB";
-        } else if (numberToFormat >= 1073741824) {
-            result = (numberToFormat / 1073741824).toPrecision(4).toString() + "GB";
-        } else if (numberToFormat >= 1048576) {
-            result = (numberToFormat / 1048576).toPrecision(4).toString() + "MB";
+        if (numberToFormat >= BYTES_IN_TERABYTE) {
+            result = (numberToFormat / BYTES_IN_TERABYTE).toPrecision(4).toString()  + "TB";
+        } else if (numberToFormat >= BYTES_IN_GIGABYTE) {
+            result = (numberToFormat / BYTES_IN_GIGABYTE).toPrecision(4).toString() + "GB";
+        } else if (numberToFormat >= BYTES_IN_MEGABYTE) {
+            result = (numberToFormat / BYTES_IN_MEGABYTE).toPrecision(4).toString() + "MB";
+        } else if (numberToFormat >= BYTES_IN_KILOBYTE) {
+            result = (numberToFormat / BYTES_IN_KILOBYTE).toPrecision(4).toString() + "KB";
         } else {
-            result = numberToFormat.toPrecision(6).toString();
+            result = numberToFormat.toPrecision(4).toString();
         }
         return result;
     }
@@ -32,7 +37,7 @@ export class SystemMetadataUtils {
         numberToFormat -= hours * 3600;
         const minutes = Math.floor(numberToFormat / 60);
         numberToFormat -= minutes * 60;
-        return "days: " + days + " hours: " + hours + " minutes: " + minutes + " seconds: " + numberToFormat;
+        return days + " days, " + hours + " hours, " + minutes + " minutes, " + numberToFormat + " seconds.";
     }
 
 }

--- a/src/io/SystemMetadata.tsx
+++ b/src/io/SystemMetadata.tsx
@@ -10,19 +10,19 @@ export interface SystemMetadata {
 export class SystemMetadataUtils {
 
   public static memoryStringFormat(numberToFormat: number) {
-    const BYTES_IN_KILOBYTE: number = 1000;
-    const BYTES_IN_MEGABYTE: number = BYTES_IN_KILOBYTE * 1000;
-    const BYTES_IN_GIGABYTE: number = BYTES_IN_MEGABYTE * 1000;
-    const BYTES_IN_TERABYTE: number = BYTES_IN_GIGABYTE * 1000;
+    const BYTES_IN_KIBIBYTE: number = 1024;
+    const BYTES_IN_MEBIBYTE: number = BYTES_IN_KIBIBYTE * 1024;
+    const BYTES_IN_GIBIBYTE: number = BYTES_IN_MEBIBYTE * 1024;
+    const BYTES_IN_TEBIBYTE: number = BYTES_IN_GIBIBYTE * 1024;
     let result: string;
-    if (numberToFormat >= BYTES_IN_TERABYTE) {
-      result = (numberToFormat / BYTES_IN_TERABYTE).toPrecision(4).toString()  + "TB";
-    } else if (numberToFormat >= BYTES_IN_GIGABYTE) {
-      result = (numberToFormat / BYTES_IN_GIGABYTE).toPrecision(4).toString() + "GB";
-    } else if (numberToFormat >= BYTES_IN_MEGABYTE) {
-      result = (numberToFormat / BYTES_IN_MEGABYTE).toPrecision(4).toString() + "MB";
-    } else if (numberToFormat >= BYTES_IN_KILOBYTE) {
-      result = (numberToFormat / BYTES_IN_KILOBYTE).toPrecision(4).toString() + "KB";
+    if (numberToFormat >= BYTES_IN_TEBIBYTE) {
+      result = (numberToFormat / BYTES_IN_TEBIBYTE).toPrecision(4).toString()  + "TiB";
+    } else if (numberToFormat >= BYTES_IN_GIBIBYTE) {
+      result = (numberToFormat / BYTES_IN_GIBIBYTE).toPrecision(4).toString() + "GiB";
+    } else if (numberToFormat >= BYTES_IN_MEBIBYTE) {
+      result = (numberToFormat / BYTES_IN_MEBIBYTE).toPrecision(4).toString() + "MiB";
+    } else if (numberToFormat >= BYTES_IN_KIBIBYTE) {
+      result = (numberToFormat / BYTES_IN_KIBIBYTE).toPrecision(4).toString() + "KiB";
     } else {
       result = numberToFormat.toPrecision(4).toString();
     }

--- a/src/io/SystemMetadata.tsx
+++ b/src/io/SystemMetadata.tsx
@@ -1,10 +1,10 @@
 export interface SystemMetadata {
   cpuUsage: number;
-  memoryUsagePercentage: number;
   memoryUsed: number;
-  memoryTotal: number;
-  memoryAvailable: number;
+  memoryMax: number;
   serverUptime: number;
+  jvmMemoryUsed: number;
+  jvmMemoryMax: number;
 }
 
 export class SystemMetadataUtils {
@@ -29,7 +29,7 @@ export class SystemMetadataUtils {
     return result;
   }
 
-  public static systemUptimeFormat(numberToFormat: number) {
+  public static serverUptimeFormat(numberToFormat: number) {
     const SECONDS_IN_MINUTE: number = 60;
     const SECONDS_IN_HOUR: number = SECONDS_IN_MINUTE * 60;
     const SECONDS_IN_DAY: number = SECONDS_IN_HOUR * 24;

--- a/src/io/SystemMetadata.tsx
+++ b/src/io/SystemMetadata.tsx
@@ -1,43 +1,47 @@
 export interface SystemMetadata {
-    cpuUsage: number;
-    memoryUsagePercentage: number;
-    memoryUsed: number;
-    memoryTotal: number;
-    memoryAvailable: number;
-    systemUptime: number;
+  cpuUsage: number;
+  memoryUsagePercentage: number;
+  memoryUsed: number;
+  memoryTotal: number;
+  memoryAvailable: number;
+  serverUptime: number;
 }
 
 export class SystemMetadataUtils {
 
-    public static memoryStringFormat(numberToFormat: number) {
-        const BYTES_IN_KILOBYTE: number = 1000;
-        const BYTES_IN_MEGABYTE: number = BYTES_IN_KILOBYTE * 1000;
-        const BYTES_IN_GIGABYTE: number = BYTES_IN_MEGABYTE * 1000;
-        const BYTES_IN_TERABYTE: number = BYTES_IN_GIGABYTE * 1000;
-        let result: string;
-        if (numberToFormat >= BYTES_IN_TERABYTE) {
-            result = (numberToFormat / BYTES_IN_TERABYTE).toPrecision(4).toString()  + "TB";
-        } else if (numberToFormat >= BYTES_IN_GIGABYTE) {
-            result = (numberToFormat / BYTES_IN_GIGABYTE).toPrecision(4).toString() + "GB";
-        } else if (numberToFormat >= BYTES_IN_MEGABYTE) {
-            result = (numberToFormat / BYTES_IN_MEGABYTE).toPrecision(4).toString() + "MB";
-        } else if (numberToFormat >= BYTES_IN_KILOBYTE) {
-            result = (numberToFormat / BYTES_IN_KILOBYTE).toPrecision(4).toString() + "KB";
-        } else {
-            result = numberToFormat.toPrecision(4).toString();
-        }
-        return result;
+  public static memoryStringFormat(numberToFormat: number) {
+    const BYTES_IN_KILOBYTE: number = 1000;
+    const BYTES_IN_MEGABYTE: number = BYTES_IN_KILOBYTE * 1000;
+    const BYTES_IN_GIGABYTE: number = BYTES_IN_MEGABYTE * 1000;
+    const BYTES_IN_TERABYTE: number = BYTES_IN_GIGABYTE * 1000;
+    let result: string;
+    if (numberToFormat >= BYTES_IN_TERABYTE) {
+      result = (numberToFormat / BYTES_IN_TERABYTE).toPrecision(4).toString()  + "TB";
+    } else if (numberToFormat >= BYTES_IN_GIGABYTE) {
+      result = (numberToFormat / BYTES_IN_GIGABYTE).toPrecision(4).toString() + "GB";
+    } else if (numberToFormat >= BYTES_IN_MEGABYTE) {
+      result = (numberToFormat / BYTES_IN_MEGABYTE).toPrecision(4).toString() + "MB";
+    } else if (numberToFormat >= BYTES_IN_KILOBYTE) {
+      result = (numberToFormat / BYTES_IN_KILOBYTE).toPrecision(4).toString() + "KB";
+    } else {
+      result = numberToFormat.toPrecision(4).toString();
     }
+    return result;
+  }
 
-    public static systemUptimeFormat(numberToFormat: number) {
-        // number of seconds in a day, hour, minute
-        const days = Math.floor(numberToFormat / 86400);
-        numberToFormat -= days * 86400;
-        const hours = Math.floor(numberToFormat / 3600);
-        numberToFormat -= hours * 3600;
-        const minutes = Math.floor(numberToFormat / 60);
-        numberToFormat -= minutes * 60;
-        return days + " days, " + hours + " hours, " + minutes + " minutes, " + numberToFormat + " seconds.";
-    }
+  public static systemUptimeFormat(numberToFormat: number) {
+    const SECONDS_IN_MINUTE: number = 60;
+    const SECONDS_IN_HOUR: number = SECONDS_IN_MINUTE * 60;
+    const SECONDS_IN_DAY: number = SECONDS_IN_HOUR * 24;
+    // convert from milliseconds to seconds
+    numberToFormat = Math.floor(numberToFormat / 1000);
+    const days = Math.floor(numberToFormat / SECONDS_IN_DAY);
+    numberToFormat -= days * SECONDS_IN_DAY;
+    const hours = Math.floor(numberToFormat / SECONDS_IN_HOUR);
+    numberToFormat -= hours * SECONDS_IN_HOUR;
+    const minutes = Math.floor(numberToFormat / SECONDS_IN_MINUTE);
+    numberToFormat -= minutes * SECONDS_IN_MINUTE;
+    return days + " days, " + hours + " hours, " + minutes + " minutes, " + numberToFormat + " seconds.";
+  }
 
 }

--- a/src/io/SystemMetadata.tsx
+++ b/src/io/SystemMetadata.tsx
@@ -1,0 +1,38 @@
+export interface SystemMetadata {
+    cpuUsage: number;
+    memoryUsagePercentage: number;
+    memoryUsed: number;
+    memoryTotal: number;
+    memoryAvailable: number;
+    systemUptime: number;
+}
+
+export class SystemMetadataUtils {
+
+    public static memoryStringFormat(numberToFormat: number) {
+        // number of bytes in a terabyte, gigabyte, and megabyte.
+        let result: string;
+        if (numberToFormat >= 1099511627776) {
+            result = (numberToFormat / 1099511627776).toPrecision(4).toString()  + "TB";
+        } else if (numberToFormat >= 1073741824) {
+            result = (numberToFormat / 1073741824).toPrecision(4).toString() + "GB";
+        } else if (numberToFormat >= 1048576) {
+            result = (numberToFormat / 1048576).toPrecision(4).toString() + "MB";
+        } else {
+            result = numberToFormat.toPrecision(6).toString();
+        }
+        return result;
+    }
+
+    public static systemUptimeFormat(numberToFormat: number) {
+        // number of seconds in a day, hour, minute
+        const days = Math.floor(numberToFormat / 86400);
+        numberToFormat -= days * 86400;
+        const hours = Math.floor(numberToFormat / 3600);
+        numberToFormat -= hours * 3600;
+        const minutes = Math.floor(numberToFormat / 60);
+        numberToFormat -= minutes * 60;
+        return "days: " + days + " hours: " + hours + " minutes: " + minutes + " seconds: " + numberToFormat;
+    }
+
+}

--- a/src/tabs/TabModel.tsx
+++ b/src/tabs/TabModel.tsx
@@ -2,6 +2,7 @@ import {IncomingMessage} from "../io/IncomingMessage";
 import {OutgoingMessage} from "../io/OutgoingMessage";
 import {ResourceRequest} from "../io/ResourceRequest";
 import {TabController} from "./TabController";
+import {ResourcePath} from "common/io/ResourcePath";
 
 export abstract class TabModel<StateType> {
 
@@ -53,8 +54,14 @@ export abstract class TabModel<StateType> {
     this.updateView(state);
   }
 
-  public requestResource = (data: ResourceRequest) =>  {
-    this.sendData({messageType: "RESOURCE_REQUEST", data});
+  public requestResource = (data: ResourceRequest) => {
+    if (this.sendData instanceof Function) {
+      this.sendData({messageType: "RESOURCE_REQUEST", data});
+    }
+  }
+
+  public requestUpdateValues = (refresh: ResourcePath) => {
+    this.requestResource({resourcePath: refresh, method: "GET"});
   }
 
 }

--- a/src/tabs/TabModel.tsx
+++ b/src/tabs/TabModel.tsx
@@ -1,8 +1,8 @@
+import {ResourcePath} from "common/io/ResourcePath";
 import {IncomingMessage} from "../io/IncomingMessage";
 import {OutgoingMessage} from "../io/OutgoingMessage";
 import {ResourceRequest} from "../io/ResourceRequest";
 import {TabController} from "./TabController";
-import {ResourcePath} from "common/io/ResourcePath";
 
 export abstract class TabModel<StateType> {
 

--- a/src/tabs/TabModel.tsx
+++ b/src/tabs/TabModel.tsx
@@ -1,4 +1,3 @@
-import {ResourcePath} from "common/io/ResourcePath";
 import {IncomingMessage} from "../io/IncomingMessage";
 import {OutgoingMessage} from "../io/OutgoingMessage";
 import {ResourceRequest} from "../io/ResourceRequest";
@@ -58,10 +57,6 @@ export abstract class TabModel<StateType> {
     if (this.sendData instanceof Function) {
       this.sendData({messageType: "RESOURCE_REQUEST", data});
     }
-  }
-
-  public requestUpdateValues = (refresh: ResourcePath) => {
-    this.requestResource({resourcePath: refresh, method: "GET"});
   }
 
 }

--- a/src/tabs/TabModel.tsx
+++ b/src/tabs/TabModel.tsx
@@ -54,9 +54,7 @@ export abstract class TabModel<StateType> {
   }
 
   public requestResource = (data: ResourceRequest) => {
-    if (this.sendData instanceof Function) {
-      this.sendData({messageType: "RESOURCE_REQUEST", data});
-    }
+    this.sendData({messageType: "RESOURCE_REQUEST", data});
   }
 
 }

--- a/src/tabs/home/HomeTabModel.tsx
+++ b/src/tabs/home/HomeTabModel.tsx
@@ -24,8 +24,8 @@ export class HomeTabModel extends ResourceSubscriberTabModel<HomeTabState> {
   }
 
   public getDefaultState(): HomeTabState {
-    return {onlinePlayers: [], engineState: {state: "UNKNOWN"}, system: {cpuUsage: 0, memoryAvailable: 0,
-            memoryTotal: 0, memoryUsagePercentage: 0, memoryUsed: 0, serverUptime: 0}, serverPort: 0, serverMotd: ""};
+    return {onlinePlayers: [], engineState: {state: "UNKNOWN"}, system: {cpuUsage: 0, memoryMax: 0, memoryUsed: 0,
+            serverUptime: 0, jvmMemoryUsed: 0, jvmMemoryMax: 0}, serverPort: 0, serverMotd: ""};
   }
 
   public initController(): TabController<null> {

--- a/src/tabs/home/HomeTabModel.tsx
+++ b/src/tabs/home/HomeTabModel.tsx
@@ -25,7 +25,7 @@ export class HomeTabModel extends ResourceSubscriberTabModel<HomeTabState> {
 
   public getDefaultState(): HomeTabState {
     return {onlinePlayers: [], engineState: {state: "UNKNOWN"}, system: {cpuUsage: 0, memoryAvailable: 0,
-            memoryTotal: 0, memoryUsagePercentage: 0, memoryUsed: 0, systemUptime: 0}, serverPort: 0, serverMotd: ""};
+            memoryTotal: 0, memoryUsagePercentage: 0, memoryUsed: 0, serverUptime: 0}, serverPort: 0, serverMotd: ""};
   }
 
   public initController(): TabController<null> {

--- a/src/tabs/home/HomeTabModel.tsx
+++ b/src/tabs/home/HomeTabModel.tsx
@@ -1,3 +1,4 @@
+import {SystemMetadata} from "common/io/SystemMetadata";
 import {EngineStateMetadata} from "../../io/EngineStateMetadata";
 import {OnlinePlayerMetadata} from "../../io/OnlinePlayerMetadata";
 import {ResourcePath, ResourcePathUtil} from "../../io/ResourcePath";
@@ -16,13 +17,15 @@ export class HomeTabModel extends ResourceSubscriberTabModel<HomeTabState> {
     return [
       ["onlinePlayers"],
       ["engineState"],
+      ["system"],
       ["config", "serverPort"],
       ["config", "MOTD"],
     ];
   }
 
   public getDefaultState(): HomeTabState {
-    return {onlinePlayers: [], engineState: {state: "UNKNOWN"}, serverPort: 0, serverMotd: ""};
+    return {onlinePlayers: [], engineState: {state: "UNKNOWN"}, system: {cpuUsage: 0, memoryAvailable: 0,
+            memoryTotal: 0, memoryUsagePercentage: 0, memoryUsed: 0, systemUptime: 0}, serverPort: 0, serverMotd: ""};
   }
 
   public initController(): TabController<null> {
@@ -34,6 +37,8 @@ export class HomeTabModel extends ResourceSubscriberTabModel<HomeTabState> {
       this.update({onlinePlayers: data as OnlinePlayerMetadata[]});
     } else if (ResourcePathUtil.equals(resourcePath, ["engineState"])) {
       this.update({engineState: data as EngineStateMetadata});
+    } else if (ResourcePathUtil.equals(resourcePath, ["system"])) {
+      this.update({system: data as SystemMetadata});
     } else if (ResourcePathUtil.equals(resourcePath, ["config", "serverPort"])) {
       this.update({serverPort: data as number});
     } else if (ResourcePathUtil.equals(resourcePath, ["config", "MOTD"])) {

--- a/src/tabs/home/HomeTabState.tsx
+++ b/src/tabs/home/HomeTabState.tsx
@@ -1,9 +1,11 @@
+import {SystemMetadata} from "common/io/SystemMetadata";
 import {EngineStateMetadata} from "../../io/EngineStateMetadata";
 import {OnlinePlayerMetadata} from "../../io/OnlinePlayerMetadata";
 
 export interface HomeTabState {
   onlinePlayers?: OnlinePlayerMetadata[];
   engineState?: EngineStateMetadata;
+  system?: SystemMetadata;
   serverMotd?: string;
   serverPort?: number;
 }

--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -24,9 +24,9 @@ export class HomeTabView extends TabView<HomeTabState> {
         <RX.Text>CPU usage: {this.state.system.cpuUsage.toPrecision(4)}%</RX.Text>
         <RX.Text>Memory usage: {this.state.system.memoryUsagePercentage.toPrecision(4)}%</RX.Text>
         <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryUsed)} /
-            {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryTotal)},
-            {" " + SystemMetadataUtils.memoryStringFormat(this.state.system.memoryAvailable)} available</RX.Text>
-        <RX.Text>System uptime: {SystemMetadataUtils.systemUptimeFormat(this.state.system.systemUptime)}</RX.Text>
+          {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryTotal)},
+          {" " + SystemMetadataUtils.memoryStringFormat(this.state.system.memoryAvailable)} available</RX.Text>
+        <RX.Text>Server uptime: {SystemMetadataUtils.systemUptimeFormat(this.state.system.serverUptime)}</RX.Text>
       </RX.View>
     );
   }

--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -12,6 +12,7 @@ export class HomeTabView extends TabView<HomeTabState> {
     // TODO: handle style leaks
     const renderColorString = (color: RgbaColor) => "rgba(" + color.r + "," + color.g + "," + color.b + "," + color.a + ")";
     const createColorStyle = (color: RgbaColor) => RX.Styles.createTextStyle({color: renderColorString(color)});
+    const system = this.state.system;
     return (
       <RX.View>
         <RX.Button onPress={this.updateValues} style={Styles.okButton}><RX.Text>Refresh</RX.Text></RX.Button>
@@ -21,12 +22,15 @@ export class HomeTabView extends TabView<HomeTabState> {
         <RX.Text>There are currently {this.state.onlinePlayers.length} players online on this server:</RX.Text>
         {this.state.onlinePlayers.map((player) => <RX.Text key={player.id} style={createColorStyle(player.color)}>{player.name}</RX.Text>)}
         <RX.Text/>
-        <RX.Text>CPU usage: {this.state.system.cpuUsage.toPrecision(4)}%</RX.Text>
-        <RX.Text>Memory usage: {this.state.system.memoryUsagePercentage.toPrecision(4)}%</RX.Text>
-        <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryUsed)} /
-          {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryTotal)},
-          {" " + SystemMetadataUtils.memoryStringFormat(this.state.system.memoryAvailable)} available</RX.Text>
-        <RX.Text>Server uptime: {SystemMetadataUtils.systemUptimeFormat(this.state.system.serverUptime)}</RX.Text>
+        <RX.Text>CPU usage: {system.cpuUsage.toPrecision(4)}%</RX.Text>
+        <RX.Text>Memory usage: {system.memoryMax === 0 ? 0 : (system.memoryUsed * 100 / system.memoryMax).toPrecision(4)}%</RX.Text>
+        <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(system.memoryUsed)} /
+          {SystemMetadataUtils.memoryStringFormat(system.memoryMax)},
+          {" " + SystemMetadataUtils.memoryStringFormat(system.memoryMax - system.memoryUsed)} available</RX.Text>
+        <RX.Text>JVM Memory used: {SystemMetadataUtils.memoryStringFormat(system.jvmMemoryUsed)} /
+          {SystemMetadataUtils.memoryStringFormat(system.jvmMemoryMax)},
+          {" " + SystemMetadataUtils.memoryStringFormat(system.jvmMemoryMax - system.jvmMemoryUsed)} available</RX.Text>
+        <RX.Text>Server uptime: {SystemMetadataUtils.serverUptimeFormat(system.serverUptime)}</RX.Text>
       </RX.View>
     );
   }

--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -15,7 +15,6 @@ export class HomeTabView extends TabView<HomeTabState> {
     const system = this.state.system;
     return (
       <RX.View>
-        <RX.Button onPress={this.updateValues} style={Styles.okButton}><RX.Text>Refresh</RX.Text></RX.Button>
         <RX.Text>Server status: {EngineStateMetadataUtils.render(this.state.engineState)}</RX.Text>
         <RX.Text>MOTD (Message Of The Day): {this.state.serverMotd}</RX.Text>
         <RX.Text>This server listens on port {this.state.serverPort}.</RX.Text>
@@ -33,12 +32,6 @@ export class HomeTabView extends TabView<HomeTabState> {
         <RX.Text>Server uptime: {SystemMetadataUtils.serverUptimeFormat(system.serverUptime)}</RX.Text>
       </RX.View>
     );
-  }
-
-  public updateValues = () => {
-    this.props.model.requestUpdateValues(["system"]);
-    this.props.model.requestUpdateValues(["engineState"]);
-    this.props.model.requestUpdateValues(["onlinePlayers"]);
   }
 
 }

--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -1,4 +1,5 @@
 import RX = require("reactxp");
+import Styles = require("../../styles/main");
 import {EngineStateMetadata, EngineStateMetadataUtils} from "../../io/EngineStateMetadata";
 import {OnlinePlayerMetadata, RgbaColor} from "../../io/OnlinePlayerMetadata";
 import {SystemMetadataUtils} from "../../io/SystemMetadata";
@@ -13,19 +14,27 @@ export class HomeTabView extends TabView<HomeTabState> {
     const createColorStyle = (color: RgbaColor) => RX.Styles.createTextStyle({color: renderColorString(color)});
     return (
       <RX.View>
+        <RX.Button onPress={this.updateValues} style={Styles.okButton}><RX.Text>Refresh</RX.Text></RX.Button>
         <RX.Text>Server status: {EngineStateMetadataUtils.render(this.state.engineState)}</RX.Text>
         <RX.Text>MOTD (Message Of The Day): {this.state.serverMotd}</RX.Text>
         <RX.Text>This server listens on port {this.state.serverPort}.</RX.Text>
         <RX.Text>There are currently {this.state.onlinePlayers.length} players online on this server:</RX.Text>
         {this.state.onlinePlayers.map((player) => <RX.Text key={player.id} style={createColorStyle(player.color)}>{player.name}</RX.Text>)}
+        <RX.Text/>
         <RX.Text>CPU usage: {this.state.system.cpuUsage.toPrecision(4)}%</RX.Text>
         <RX.Text>Memory usage: {this.state.system.memoryUsagePercentage.toPrecision(4)}%</RX.Text>
         <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryUsed)} /
             {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryTotal)},
-            {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryAvailable)} available</RX.Text>
+            {" " + SystemMetadataUtils.memoryStringFormat(this.state.system.memoryAvailable)} available</RX.Text>
         <RX.Text>System uptime: {SystemMetadataUtils.systemUptimeFormat(this.state.system.systemUptime)}</RX.Text>
       </RX.View>
     );
+  }
+
+  public updateValues = () => {
+    this.props.model.requestUpdateValues(["system"]);
+    this.props.model.requestUpdateValues(["engineState"]);
+    this.props.model.requestUpdateValues(["onlinePlayers"]);
   }
 
 }

--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -1,6 +1,7 @@
 import RX = require("reactxp");
 import {EngineStateMetadata, EngineStateMetadataUtils} from "../../io/EngineStateMetadata";
 import {OnlinePlayerMetadata, RgbaColor} from "../../io/OnlinePlayerMetadata";
+import {SystemMetadataUtils} from "../../io/SystemMetadata";
 import {TabView} from "../TabView";
 import {HomeTabState} from "./HomeTabState";
 
@@ -17,6 +18,12 @@ export class HomeTabView extends TabView<HomeTabState> {
         <RX.Text>This server listens on port {this.state.serverPort}.</RX.Text>
         <RX.Text>There are currently {this.state.onlinePlayers.length} players online on this server:</RX.Text>
         {this.state.onlinePlayers.map((player) => <RX.Text key={player.id} style={createColorStyle(player.color)}>{player.name}</RX.Text>)}
+        <RX.Text>CPU usage: {this.state.system.cpuUsage.toPrecision(4)}%</RX.Text>
+        <RX.Text>Memory usage: {this.state.system.memoryUsagePercentage.toPrecision(4)}%</RX.Text>
+        <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryUsed)} /
+            {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryTotal)},
+            {SystemMetadataUtils.memoryStringFormat(this.state.system.memoryAvailable)} available</RX.Text>
+        <RX.Text>System uptime: {SystemMetadataUtils.systemUptimeFormat(this.state.system.systemUptime)}</RX.Text>
       </RX.View>
     );
   }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
       "interface-name": [true, "never-prefix"],
       "max-line-length": [true, 140],
       "jsx-no-lambda": false,
-      "jsx-alignment": false
+      "jsx-alignment": false,
+      "object-literal-sort-keys": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
This PR adds a frontend for the system status data exposed over REST. As such, the backend repo should be merged before this one. Most of what I am doing here is just using the existing abstraction to add on to the frontend. At the moment, the data does not get refreshed at all after the first time the server is loaded up, so don't merge this yet. To test this, start up the server facade (with the backend changes implemented) and look at the home screen.

Here is what we need done before merging:
~~- [ ] Either add a button to refresh the frontend data or automatically do so every second. I think that automatically refreshing would be better.~~
Actually, this should go in a separate PR. This should be ready for merging.

backend PR: https://github.com/MovingBlocks/FacadeServer/pull/13