### PR TITLE
Make the console autocomplete commands upon hitting tab

### DIFF
--- a/src/tabs/console/ConsoleAutocomplete.tsx
+++ b/src/tabs/console/ConsoleAutocomplete.tsx
@@ -51,7 +51,7 @@ export class ConsoleAutocomplete {
   // set the list of commands provided by the backend
   public static setCommandList(commands: string[]) {
     if (this.commandList.length === 0) {
-      this.commandList = commands;
+      this.commandList = commands.sort();
     }
   }
 

--- a/src/tabs/console/ConsoleAutocomplete.tsx
+++ b/src/tabs/console/ConsoleAutocomplete.tsx
@@ -17,6 +17,8 @@ export class ConsoleAutocomplete {
     // if matches were found, do nothing to the command
     if (this.matches.length === 0) {
       return command;
+    } else if (this.matches.length === 1) {
+      return this.matches[0];
     }
     // If the last possible match has already been iterated through, reset the index to the first location.
     // The match index must be offset because the length function returns 1 with one element, but its index

--- a/src/tabs/console/ConsoleAutocomplete.tsx
+++ b/src/tabs/console/ConsoleAutocomplete.tsx
@@ -24,7 +24,6 @@ export class ConsoleAutocomplete {
     if (this.matchIndex + 1 === this.matches.length) {
       this.matchIndex = -1;
     }
-    console.log(this.matches);
     // If the first command entered had more than one match, cycle throught the matches.
     // previousCommands is always at least size 1.
     if (this.previousCommands.indexOf(this.previousCommands[0]) !== -1 && this.previousCommands.length !== 1) {

--- a/src/tabs/console/ConsoleAutocomplete.tsx
+++ b/src/tabs/console/ConsoleAutocomplete.tsx
@@ -3,6 +3,15 @@
 
 export class ConsoleAutocomplete {
 
+  // the matches currently found
+  private static matches: string[] = [];
+  // the index of the current match
+  private static matchIndex: number = 0;
+  // the commands entered before this one
+  private static previousCommands: string[] = [];
+  // a list of commands given by the REST API for console GET
+  private static commandList: string[] = [];
+
   // autocomplete the command.
   public static complete(command: string): string {
     this.previousCommands.push(command);
@@ -21,14 +30,12 @@ export class ConsoleAutocomplete {
       return this.matches[0];
     }
     // If the last possible match has already been iterated through, reset the index to the first location.
-    // The match index must be offset because the length function returns 1 with one element, but its index
-    // is zero.
     if (this.matchIndex + 1 === this.matches.length) {
       this.matchIndex = -1;
     }
-    // If the first command entered had more than one match, cycle throught the matches.
-    // previousCommands is always at least size 1.
-    if (this.previousCommands.indexOf(this.previousCommands[0]) !== -1 && this.previousCommands.length !== 1) {
+    // If there is more than one match (as required by the if/else statement above)
+    // and this is not the first command entered, then cycle through the matches.
+    if (this.previousCommands.length !== 1) {
       ++this.matchIndex;
     }
     return this.matches[this.matchIndex];
@@ -48,23 +55,9 @@ export class ConsoleAutocomplete {
     }
   }
 
-  // the matches currently found
-  private static matches: string[] = [];
-  // the index of the current match
-  private static matchIndex: number = 0;
-  // the commands entered before this one
-  private static previousCommands: string[] = [];
-  // a list of commands given by the REST API for console GET
-  private static commandList: string[] = [];
-
   // find the possible matches of the given command, using the command list provided by the REST API
   private static findMatches(command: string): void {
-    this.matches = [];
-    this.commandList.forEach((match) => {
-      if (match.indexOf(command) === 0) {
-        this.matches.push(match);
-      }
-    });
+    this.matches = this.commandList.filter((cmd) => cmd.indexOf(command) === 0);
   }
 
 }

--- a/src/tabs/console/ConsoleAutocomplete.tsx
+++ b/src/tabs/console/ConsoleAutocomplete.tsx
@@ -1,0 +1,69 @@
+// Tab completion engine for autocompleting commands. Inspired by the TabCompletionEngine class
+// for the Terasology in-game console.
+
+export class ConsoleAutocomplete {
+
+  // autocomplete the command.
+  public static complete(command: string): string {
+    this.previousCommands.push(command);
+    // if command was not entered, display some help text
+    if (command.length <= 0) {
+      return "Type 'help' to list all commands.";
+    }
+    // if no commands were previously entered, find a list of commands
+    if (this.previousCommands.length === 1) {
+      this.findMatches(command);
+    }
+    // if matches were found, do nothing to the command
+    if (this.matches.length === 0) {
+      return command;
+    }
+    // If the last possible match has already been iterated through, reset the index to the first location.
+    // The match index must be offset because the length function returns 1 with one element, but its index
+    // is zero.
+    if (this.matchIndex + 1 === this.matches.length) {
+      this.matchIndex = -1;
+    }
+    console.log(this.matches);
+    // If the first command entered had more than one match, cycle throught the matches.
+    // previousCommands is always at least size 1.
+    if (this.previousCommands.indexOf(this.previousCommands[0]) !== -1 && this.previousCommands.length !== 1) {
+      ++this.matchIndex;
+    }
+    return this.matches[this.matchIndex];
+  }
+
+  // reset the state of autocompletion
+  public static clear() {
+    this.matches = [];
+    this.matchIndex = 0;
+    this.previousCommands = [];
+  }
+
+  // set the list of commands provided by the backend
+  public static setCommandList(commands: string[]) {
+    if (this.commandList.length === 0) {
+      this.commandList = commands;
+    }
+  }
+
+  // the matches currently found
+  private static matches: string[] = [];
+  // the index of the current match
+  private static matchIndex: number = 0;
+  // the commands entered before this one
+  private static previousCommands: string[] = [];
+  // a list of commands given by the REST API for console GET
+  private static commandList: string[] = [];
+
+  // find the possible matches of the given command, using the command list provided by the REST API
+  private static findMatches(command: string): void {
+    this.matches = [];
+    this.commandList.forEach((match) => {
+      if (match.indexOf(command) === 0) {
+        this.matches.push(match);
+      }
+    });
+  }
+
+}

--- a/src/tabs/console/ConsoleTabModel.tsx
+++ b/src/tabs/console/ConsoleTabModel.tsx
@@ -1,25 +1,39 @@
 import {IncomingMessage} from "../../io/IncomingMessage";
+import {ResourcePath} from "../../io/ResourcePath";
 import {ResourcePathUtil} from "../../io/ResourcePath";
+import {ResourceSubscriberTabModel} from "../ResourceSubscriberTabModel";
 import {TabController} from "../TabController";
-import {TabModel} from "../TabModel";
 import {ConsoleTabController} from "./ConsoleTabController";
 import {ConsoleTabState, Message} from "./ConsoleTabState";
 
-export class ConsoleTabModel extends TabModel<ConsoleTabState> {
+export class ConsoleTabModel extends ResourceSubscriberTabModel<ConsoleTabState> {
 
   public getName(): string {
     return "Console";
   }
 
+  public getSubscribedResourcePaths(): ResourcePath[] {
+    return [
+      ["console"],
+    ];
+  }
+
   public getDefaultState(): ConsoleTabState {
-    return {messages: [], commandToSend: "Type a command here..."};
+    return {messages: [], commandToSend: "Type a command here...", commands: []};
   }
 
   public initController(): TabController<ConsoleTabState> {
     return new ConsoleTabController();
   }
 
+  public onResourceUpdated(resourcePath: ResourcePath, data: any): void {
+    if (ResourcePathUtil.equals(resourcePath, ["console"])) {
+      this.update({commands: data as string[]});
+    }
+  }
+
   public onMessage(message: IncomingMessage) {
+    super.onMessage(message);
     if (message.messageType === "RESOURCE_EVENT" && ResourcePathUtil.equals(message.resourcePath, ["console"])) {
       const oldState: ConsoleTabState = this.getState();
       this.update({messages: oldState.messages.concat((message.data) as Message)});

--- a/src/tabs/console/ConsoleTabState.tsx
+++ b/src/tabs/console/ConsoleTabState.tsx
@@ -6,4 +6,5 @@ export interface Message {
 export interface ConsoleTabState {
   messages?: Message[];
   commandToSend?: string;
+  commands?: string[];
 }

--- a/src/tabs/console/ConsoleTabView.tsx
+++ b/src/tabs/console/ConsoleTabView.tsx
@@ -28,15 +28,15 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
           <RX.View>
             {this.state.messages.map((msg, index) => <RX.Text key={index}>[{msg.type}] {this.renderMessage(msg.message)}</RX.Text>)}
           </RX.View>
-          <RX.View style={Styles.flex.row}>
-            <RX.TextInput
-              style={[Styles.whiteBox, Styles.commandTextInput]}
-              value={this.state.commandToSend}
-              onChangeText={this.onChangeValue}
-              autoFocus={true}
-              onKeyPress={(event) => {if (event.keyCode === 9) {this.autoComplete(this.state.commandToSend); }}}/>
-            <RX.Button style={Styles.okButton} onPress={controller.execute}><RX.Text>Execute</RX.Text></RX.Button>
-          </RX.View>
+        </RX.View>
+        <RX.View style={Styles.flex.row}>
+          <RX.TextInput
+            style={[Styles.whiteBox, Styles.commandTextInput]}
+            value={this.state.commandToSend}
+            onChangeText={this.onChangeValue}
+            autoFocus={true}
+            onKeyPress={(event) => {if (event.keyCode === 9) {this.autoComplete(this.state.commandToSend); }}}/>
+          <RX.Button style={Styles.okButton} onPress={controller.execute}><RX.Text>Execute</RX.Text></RX.Button>
         </RX.View>
       </RX.ScrollView>
     );
@@ -90,18 +90,8 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
   }
 
   private autoComplete(command: string) {
-    if (this.state.commands.length === 0) {
-      this.getCommands();
-    }
     ConsoleAutocomplete.setCommandList(this.state.commands);
     this.props.model.update({commandToSend: ConsoleAutocomplete.complete(command)});
-  }
-
-  private getCommands(): any {
-    this.props.model.requestResource({
-      method: "GET",
-      resourcePath: ["console"],
-    });
   }
 
 }

--- a/src/tabs/console/ConsoleTabView.tsx
+++ b/src/tabs/console/ConsoleTabView.tsx
@@ -94,9 +94,7 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
       this.getCommands();
     }
     ConsoleAutocomplete.setCommandList(this.state.commands);
-    console.log(this.state.commandToSend);
     this.props.model.update({commandToSend: ConsoleAutocomplete.complete(command)});
-    console.log(this.state.commandToSend);
   }
 
   private getCommands(): any {

--- a/src/tabs/console/ConsoleTabView.tsx
+++ b/src/tabs/console/ConsoleTabView.tsx
@@ -35,7 +35,7 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
             value={this.state.commandToSend}
             onChangeText={this.onChangeValue}
             autoFocus={true}
-            onKeyPress={(event) => {if (event.keyCode === 9) {this.autoComplete(this.state.commandToSend); }}}/>
+            onKeyPress={(event) =>  {this.handleKeypress(event, controller); }}/>
           <RX.Button style={Styles.okButton} onPress={controller.execute}><RX.Text>Execute</RX.Text></RX.Button>
         </RX.View>
       </RX.ScrollView>
@@ -92,6 +92,14 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
   private autoComplete(command: string) {
     ConsoleAutocomplete.setCommandList(this.state.commands);
     this.props.model.update({commandToSend: ConsoleAutocomplete.complete(command)});
+  }
+
+  private handleKeypress(event: any, controller: ConsoleTabController) {
+    if (event.keyCode === 9) {
+      this.autoComplete(this.state.commandToSend);
+    } else if (event.keyCode === 13) {
+      controller.execute();
+    }
   }
 
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
       "interface-name": [true, "never-prefix"],
       "max-line-length": [true, 140],
       "jsx-no-lambda": false,
-      "jsx-alignment": false
+      "jsx-alignment": false,
+      "member-ordering": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
The new class, ConsoleAutocomplete, provides all the logic needed to do a cycling autocomplete. It doesn't support camelCase commands like the CyclingTabCompletionEngine, but I don't think it matters too much. The rest of the changes integrate the new class into the existing code.

Also, I added a scroll bar to the console, because it really needed one. There are some problems with this implementation, such as how it doesn't automatically scroll down all the way and how the place to execute console commands loses focus on executing a command or when pressing tab. autoFocus helps, but I think that I should make a new PR sometime to keep focus on the command execution box.