### PR TITLE
Frontend for Admin permissions

### DIFF
--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -23,10 +23,10 @@ export class HomeTabView extends TabView<HomeTabState> {
         <RX.Text/>
         <RX.Text>CPU usage: {system.cpuUsage.toPrecision(4)}%</RX.Text>
         <RX.Text>Memory usage: {system.memoryMax === 0 ? 0 : (system.memoryUsed * 100 / system.memoryMax).toPrecision(4)}%</RX.Text>
-        <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(system.memoryUsed)} /
+        <RX.Text>Memory used/total: {SystemMetadataUtils.memoryStringFormat(system.memoryUsed)}/
           {SystemMetadataUtils.memoryStringFormat(system.memoryMax)},
           {" " + SystemMetadataUtils.memoryStringFormat(system.memoryMax - system.memoryUsed)} available</RX.Text>
-        <RX.Text>JVM Memory used: {SystemMetadataUtils.memoryStringFormat(system.jvmMemoryUsed)} /
+        <RX.Text>JVM Memory used: {SystemMetadataUtils.memoryStringFormat(system.jvmMemoryUsed)}/
           {SystemMetadataUtils.memoryStringFormat(system.jvmMemoryMax)},
           {" " + SystemMetadataUtils.memoryStringFormat(system.jvmMemoryMax - system.jvmMemoryUsed)} available</RX.Text>
         <RX.Text>Server uptime: {SystemMetadataUtils.serverUptimeFormat(system.serverUptime)}</RX.Text>

--- a/src/tabs/home/HomeTabView.tsx
+++ b/src/tabs/home/HomeTabView.tsx
@@ -1,7 +1,6 @@
 import RX = require("reactxp");
-import Styles = require("../../styles/main");
-import {EngineStateMetadata, EngineStateMetadataUtils} from "../../io/EngineStateMetadata";
-import {OnlinePlayerMetadata, RgbaColor} from "../../io/OnlinePlayerMetadata";
+import {EngineStateMetadataUtils} from "../../io/EngineStateMetadata";
+import {RgbaColor} from "../../io/OnlinePlayerMetadata";
 import {SystemMetadataUtils} from "../../io/SystemMetadata";
 import {TabView} from "../TabView";
 import {HomeTabState} from "./HomeTabState";

--- a/src/tabs/serverAdmins/AdminPermissions.tsx
+++ b/src/tabs/serverAdmins/AdminPermissions.tsx
@@ -12,7 +12,7 @@ export interface Permissions {
   ADMIN_MANAGEMENT: boolean;
 }
 
-// These variable names must not change due to how the Java Pair class serializes data.
+// These variable names must not change due to how the data is serialized on the backend.
 export interface AdminPermissions {
   id: string;
   permissions: Permissions;

--- a/src/tabs/serverAdmins/AdminPermissions.tsx
+++ b/src/tabs/serverAdmins/AdminPermissions.tsx
@@ -14,6 +14,6 @@ export interface Permissions {
 
 // These variable names must not change due to how the Java Pair class serializes data.
 export interface AdminPermissions {
-  key: string;
-  value: Permissions;
+  id: string;
+  permissions: Permissions;
 }

--- a/src/tabs/serverAdmins/AdminPermissions.tsx
+++ b/src/tabs/serverAdmins/AdminPermissions.tsx
@@ -1,0 +1,19 @@
+// Must be the same as the enum variable names in the backend.
+export interface Permissions {
+  CONSOLE_CHEAT: boolean;
+  CONSOLE_USER_MANAGEMENT: boolean;
+  CONSOLE_SERVER_MANAGEMENT: boolean;
+  CONSOLE_DEBUG: boolean;
+  INSTALL_MODULES: boolean;
+  CREATE_BACKUP_RENAME_GAMES: boolean;
+  DELETE_GAMES: boolean;
+  START_STOP_GAMES: boolean;
+  CHANGE_SETTINGS: boolean;
+  ADMIN_MANAGEMENT: boolean;
+}
+
+// These variable names must not change due to how the Java Pair class serializes data.
+export interface AdminPermissions {
+  key: string;
+  value: Permissions;
+}

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -25,7 +25,13 @@ export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialo
     return (
       <RX.View style={Styles.whiteBox}>
         <RX.Text>Admin Permission Management</RX.Text>
-        <CheckBox text={"console"} onCheckedChange={null} checkedByDefault={false}/>
+        <CheckBox text={"Execute Console Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Install Modules"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Create/Backup/Rename Games"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Stop Games"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Delete Games"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Change Settings"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"User Management"} onCheckedChange={undefined} checkedByDefault={false}/>
         <OkCancelButtonBar onOk={this.onOk} onCancel={this.onCancel} />
       </RX.View>
     );

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -2,52 +2,105 @@ import RX = require("reactxp");
 import Styles = require("../../styles/main");
 import {CheckBox} from "../../components/CheckBox";
 import {OkCancelButtonBar} from "../../OkCancelButtonBar";
+import {AdminPermissions} from "./ServerAdminsTabState";
 
 interface ManagePermissionsDialogProps {
-  okCallback: (clientId: string) => void;
+  adminId: string;
+  okCallback: (adminId: string, newPermissions: AdminPermissions) => void;
+  adminPermissions: AdminPermissions;
 }
 
-interface ManagePermissionsDialogState {
-  selectedClientId: string;
-}
+export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialogProps, null> {
 
-export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialogProps, ManagePermissionsDialogState> {
-
-  public static show(okCallback: (clientId: string) => void) {
-    RX.Modal.show(<ManagePermissionsDialog okCallback={okCallback} />, "addFromOnlinePlayersDialog");
-  }
-
-  public componentWillMount() {
-    this.setState({selectedClientId: null});
+  public static show(adminId: string, okCallback: (adminId: string, newPermissions: AdminPermissions) => void,
+                     adminPermissions: AdminPermissions) {
+    RX.Modal.show(
+      <ManagePermissionsDialog adminId={adminId} okCallback={okCallback} adminPermissions={adminPermissions} />, "managePermissionsDialog",
+    );
   }
 
   public render() {
-    // TODO: change onCheckedChange to allow changing commands (maybe use a state?)
     return (
       <RX.View style={Styles.whiteBox}>
         <RX.Text>Admin Permission Management</RX.Text>
-        <CheckBox text={"Execute Console Cheat Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Execute Console User Management Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Execute Console Server Management Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Execute Console Debug Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Install Modules"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Create/Backup/Rename Games"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Stop Games"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Delete Games"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Change Settings"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"User Management"} onCheckedChange={undefined} checkedByDefault={false}/>
-        <CheckBox text={"Admin Management"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Execute Console Cheat Commands"}
+                  onCheckedChange={(checked) => this.updatePermission(0, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.consoleCheat}/>
+        <CheckBox text={"Execute Console User Management Commands"}
+                  onCheckedChange={(checked) => this.updatePermission(1, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.consoleUserManagement}/>
+        <CheckBox text={"Execute Console Server Management Commands"}
+                  onCheckedChange={(checked) => this.updatePermission(2, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.consoleServerManagement}/>
+        <CheckBox text={"Execute Console Debug Commands"}
+                  onCheckedChange={(checked) => this.updatePermission(3, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.consoleDebug}/>
+        <CheckBox text={"Install Modules"}
+                  onCheckedChange={(checked) => this.updatePermission(4, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.installModules}/>
+        <CheckBox text={"Create/Backup/Rename Games"}
+                  onCheckedChange={(checked) => this.updatePermission(5, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.createBackupRenameGames}/>
+        <CheckBox text={"Stop Games"}
+                  onCheckedChange={(checked) => this.updatePermission(6, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.startStopGames}/>
+        <CheckBox text={"Delete Games"}
+                  onCheckedChange={(checked) => this.updatePermission(7, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.deleteGames}/>
+        <CheckBox text={"Change Settings"}
+                  onCheckedChange={(checked) => this.updatePermission(8, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.changeSettings}/>
+        <CheckBox text={"Admin Management"}
+                  onCheckedChange={(checked) => this.updatePermission(9, checked)}
+                  checkedByDefault={this.props.adminPermissions.permissions.adminManagement}/>
         <OkCancelButtonBar onOk={this.onOk} onCancel={this.onCancel} />
       </RX.View>
     );
   }
 
+  private updatePermission(index: number, checked: boolean) {
+    if (this.props.adminPermissions.permissions.adminManagement) {
+      switch (index) {
+        case 0:
+          this.props.adminPermissions.permissions.consoleCheat = checked;
+          break;
+        case 1:
+          this.props.adminPermissions.permissions.consoleUserManagement = checked;
+          break;
+        case 2:
+          this.props.adminPermissions.permissions.consoleServerManagement = checked;
+          break;
+        case 3:
+          this.props.adminPermissions.permissions.consoleDebug = checked;
+          break;
+        case 4:
+          this.props.adminPermissions.permissions.installModules = checked;
+          break;
+        case 5:
+          this.props.adminPermissions.permissions.createBackupRenameGames = checked;
+          break;
+        case 6:
+          this.props.adminPermissions.permissions.startStopGames = checked;
+          break;
+        case 7:
+          this.props.adminPermissions.permissions.deleteGames = checked;
+          break;
+        case 8:
+          this.props.adminPermissions.permissions.changeSettings = checked;
+          break;
+        case 9:
+          this.props.adminPermissions.permissions.adminManagement = checked;
+          break;
+      }
+    }
+  }
+
   private onOk = () => {
-    this.props.okCallback(this.state.selectedClientId);
-    RX.Modal.dismiss("addFromOnlinePlayersDialog");
+    this.props.okCallback(this.props.adminId, this.props.adminPermissions);
+    RX.Modal.dismiss("managePermissionsDialog");
   }
 
   private onCancel = () => {
-    RX.Modal.dismiss("addFromOnlinePlayersDialog");
+    RX.Modal.dismiss("managePermissionsDialog");
   }
 }

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -59,39 +59,37 @@ export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialo
   }
 
   private updatePermission(index: number, checked: boolean) {
-    if (this.props.adminPermissions.permissions.adminManagement) {
-      switch (index) {
-        case 0:
-          this.props.adminPermissions.permissions.consoleCheat = checked;
-          break;
-        case 1:
-          this.props.adminPermissions.permissions.consoleUserManagement = checked;
-          break;
-        case 2:
-          this.props.adminPermissions.permissions.consoleServerManagement = checked;
-          break;
-        case 3:
-          this.props.adminPermissions.permissions.consoleDebug = checked;
-          break;
-        case 4:
-          this.props.adminPermissions.permissions.installModules = checked;
-          break;
-        case 5:
-          this.props.adminPermissions.permissions.createBackupRenameGames = checked;
-          break;
-        case 6:
-          this.props.adminPermissions.permissions.startStopGames = checked;
-          break;
-        case 7:
-          this.props.adminPermissions.permissions.deleteGames = checked;
-          break;
-        case 8:
-          this.props.adminPermissions.permissions.changeSettings = checked;
-          break;
-        case 9:
-          this.props.adminPermissions.permissions.adminManagement = checked;
-          break;
-      }
+    switch (index) {
+      case 0:
+        this.props.adminPermissions.permissions.consoleCheat = checked;
+        break;
+      case 1:
+        this.props.adminPermissions.permissions.consoleUserManagement = checked;
+        break;
+      case 2:
+        this.props.adminPermissions.permissions.consoleServerManagement = checked;
+        break;
+      case 3:
+        this.props.adminPermissions.permissions.consoleDebug = checked;
+        break;
+      case 4:
+        this.props.adminPermissions.permissions.installModules = checked;
+        break;
+      case 5:
+        this.props.adminPermissions.permissions.createBackupRenameGames = checked;
+        break;
+      case 6:
+        this.props.adminPermissions.permissions.startStopGames = checked;
+        break;
+      case 7:
+        this.props.adminPermissions.permissions.deleteGames = checked;
+        break;
+      case 8:
+        this.props.adminPermissions.permissions.changeSettings = checked;
+        break;
+      case 9:
+        this.props.adminPermissions.permissions.adminManagement = checked;
+        break;
     }
   }
 

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -2,10 +2,9 @@ import RX = require("reactxp");
 import Styles = require("../../styles/main");
 import {CheckBox} from "../../components/CheckBox";
 import {OkCancelButtonBar} from "../../OkCancelButtonBar";
-import {AdminPermissions} from "./ServerAdminsTabState";
+import {AdminPermissions} from "./AdminPermissions";
 
 interface ManagePermissionsDialogProps {
-  adminId: string;
   okCallback: (adminId: string, newPermissions: AdminPermissions) => void;
   adminPermissions: AdminPermissions;
 }
@@ -15,7 +14,7 @@ export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialo
   public static show(adminId: string, okCallback: (adminId: string, newPermissions: AdminPermissions) => void,
                      adminPermissions: AdminPermissions) {
     RX.Modal.show(
-      <ManagePermissionsDialog adminId={adminId} okCallback={okCallback} adminPermissions={adminPermissions} />, "managePermissionsDialog",
+      <ManagePermissionsDialog okCallback={okCallback} adminPermissions={adminPermissions} />, "managePermissionsDialog",
     );
   }
 
@@ -24,77 +23,42 @@ export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialo
       <RX.View style={Styles.whiteBox}>
         <RX.Text>Admin Permission Management</RX.Text>
         <CheckBox text={"Execute Console Cheat Commands"}
-                  onCheckedChange={(checked) => this.updatePermission(0, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.consoleCheat}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_CHEAT = checked}
+                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_CHEAT}/>
         <CheckBox text={"Execute Console User Management Commands"}
-                  onCheckedChange={(checked) => this.updatePermission(1, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.consoleUserManagement}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_USER_MANAGEMENT = checked}
+                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_USER_MANAGEMENT}/>
         <CheckBox text={"Execute Console Server Management Commands"}
-                  onCheckedChange={(checked) => this.updatePermission(2, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.consoleServerManagement}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_SERVER_MANAGEMENT = checked}
+                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_SERVER_MANAGEMENT}/>
         <CheckBox text={"Execute Console Debug Commands"}
-                  onCheckedChange={(checked) => this.updatePermission(3, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.consoleDebug}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_DEBUG = checked}
+                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_DEBUG}/>
         <CheckBox text={"Install Modules"}
-                  onCheckedChange={(checked) => this.updatePermission(4, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.installModules}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.INSTALL_MODULES = checked}
+                  checkedByDefault={this.props.adminPermissions.value.INSTALL_MODULES}/>
         <CheckBox text={"Create/Backup/Rename Games"}
-                  onCheckedChange={(checked) => this.updatePermission(5, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.createBackupRenameGames}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.CREATE_BACKUP_RENAME_GAMES = checked}
+                  checkedByDefault={this.props.adminPermissions.value.CREATE_BACKUP_RENAME_GAMES}/>
         <CheckBox text={"Stop Games"}
-                  onCheckedChange={(checked) => this.updatePermission(6, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.startStopGames}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.START_STOP_GAMES = checked}
+                  checkedByDefault={this.props.adminPermissions.value.START_STOP_GAMES}/>
         <CheckBox text={"Delete Games"}
-                  onCheckedChange={(checked) => this.updatePermission(7, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.deleteGames}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.DELETE_GAMES = checked}
+                  checkedByDefault={this.props.adminPermissions.value.DELETE_GAMES}/>
         <CheckBox text={"Change Settings"}
-                  onCheckedChange={(checked) => this.updatePermission(8, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.changeSettings}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.CHANGE_SETTINGS = checked}
+                  checkedByDefault={this.props.adminPermissions.value.CHANGE_SETTINGS}/>
         <CheckBox text={"Admin Management"}
-                  onCheckedChange={(checked) => this.updatePermission(9, checked)}
-                  checkedByDefault={this.props.adminPermissions.permissions.adminManagement}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.value.ADMIN_MANAGEMENT = checked}
+                  checkedByDefault={this.props.adminPermissions.value.ADMIN_MANAGEMENT}/>
         <OkCancelButtonBar onOk={this.onOk} onCancel={this.onCancel} />
       </RX.View>
     );
   }
 
-  private updatePermission(index: number, checked: boolean) {
-    switch (index) {
-      case 0:
-        this.props.adminPermissions.permissions.consoleCheat = checked;
-        break;
-      case 1:
-        this.props.adminPermissions.permissions.consoleUserManagement = checked;
-        break;
-      case 2:
-        this.props.adminPermissions.permissions.consoleServerManagement = checked;
-        break;
-      case 3:
-        this.props.adminPermissions.permissions.consoleDebug = checked;
-        break;
-      case 4:
-        this.props.adminPermissions.permissions.installModules = checked;
-        break;
-      case 5:
-        this.props.adminPermissions.permissions.createBackupRenameGames = checked;
-        break;
-      case 6:
-        this.props.adminPermissions.permissions.startStopGames = checked;
-        break;
-      case 7:
-        this.props.adminPermissions.permissions.deleteGames = checked;
-        break;
-      case 8:
-        this.props.adminPermissions.permissions.changeSettings = checked;
-        break;
-      case 9:
-        this.props.adminPermissions.permissions.adminManagement = checked;
-        break;
-    }
-  }
-
   private onOk = () => {
-    this.props.okCallback(this.props.adminId, this.props.adminPermissions);
+    this.props.okCallback(this.props.adminPermissions.key, this.props.adminPermissions);
     RX.Modal.dismiss("managePermissionsDialog");
   }
 

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -23,42 +23,42 @@ export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialo
       <RX.View style={Styles.whiteBox}>
         <RX.Text>Admin Permission Management</RX.Text>
         <CheckBox text={"Execute Console Cheat Commands"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_CHEAT = checked}
-                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_CHEAT}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.CONSOLE_CHEAT = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.CONSOLE_CHEAT}/>
         <CheckBox text={"Execute Console User Management Commands"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_USER_MANAGEMENT = checked}
-                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_USER_MANAGEMENT}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.CONSOLE_USER_MANAGEMENT = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.CONSOLE_USER_MANAGEMENT}/>
         <CheckBox text={"Execute Console Server Management Commands"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_SERVER_MANAGEMENT = checked}
-                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_SERVER_MANAGEMENT}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.CONSOLE_SERVER_MANAGEMENT = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.CONSOLE_SERVER_MANAGEMENT}/>
         <CheckBox text={"Execute Console Debug Commands"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.CONSOLE_DEBUG = checked}
-                  checkedByDefault={this.props.adminPermissions.value.CONSOLE_DEBUG}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.CONSOLE_DEBUG = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.CONSOLE_DEBUG}/>
         <CheckBox text={"Install Modules"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.INSTALL_MODULES = checked}
-                  checkedByDefault={this.props.adminPermissions.value.INSTALL_MODULES}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.INSTALL_MODULES = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.INSTALL_MODULES}/>
         <CheckBox text={"Create/Backup/Rename Games"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.CREATE_BACKUP_RENAME_GAMES = checked}
-                  checkedByDefault={this.props.adminPermissions.value.CREATE_BACKUP_RENAME_GAMES}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.CREATE_BACKUP_RENAME_GAMES = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.CREATE_BACKUP_RENAME_GAMES}/>
         <CheckBox text={"Stop Games"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.START_STOP_GAMES = checked}
-                  checkedByDefault={this.props.adminPermissions.value.START_STOP_GAMES}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.START_STOP_GAMES = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.START_STOP_GAMES}/>
         <CheckBox text={"Delete Games"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.DELETE_GAMES = checked}
-                  checkedByDefault={this.props.adminPermissions.value.DELETE_GAMES}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.DELETE_GAMES = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.DELETE_GAMES}/>
         <CheckBox text={"Change Settings"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.CHANGE_SETTINGS = checked}
-                  checkedByDefault={this.props.adminPermissions.value.CHANGE_SETTINGS}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.CHANGE_SETTINGS = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.CHANGE_SETTINGS}/>
         <CheckBox text={"Admin Management"}
-                  onCheckedChange={(checked) => this.props.adminPermissions.value.ADMIN_MANAGEMENT = checked}
-                  checkedByDefault={this.props.adminPermissions.value.ADMIN_MANAGEMENT}/>
+                  onCheckedChange={(checked) => this.props.adminPermissions.permissions.ADMIN_MANAGEMENT = checked}
+                  checkedByDefault={this.props.adminPermissions.permissions.ADMIN_MANAGEMENT}/>
         <OkCancelButtonBar onOk={this.onOk} onCancel={this.onCancel} />
       </RX.View>
     );
   }
 
   private onOk = () => {
-    this.props.okCallback(this.props.adminPermissions.key, this.props.adminPermissions);
+    this.props.okCallback(this.props.adminPermissions.id, this.props.adminPermissions);
     RX.Modal.dismiss("managePermissionsDialog");
   }
 

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -1,0 +1,42 @@
+import RX = require("reactxp");
+import Styles = require("../../styles/main");
+import {CheckBox} from "../../components/CheckBox";
+import {OkCancelButtonBar} from "../../OkCancelButtonBar";
+
+interface ManagePermissionsDialogProps {
+  okCallback: (clientId: string) => void;
+}
+
+interface ManagePermissionsDialogState {
+  selectedClientId: string;
+}
+
+export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialogProps, ManagePermissionsDialogState> {
+
+  public static show(okCallback: (clientId: string) => void) {
+    RX.Modal.show(<ManagePermissionsDialog okCallback={okCallback} />, "addFromOnlinePlayersDialog");
+  }
+
+  public componentWillMount() {
+    this.setState({selectedClientId: null});
+  }
+
+  public render() {
+    return (
+      <RX.View style={Styles.whiteBox}>
+        <RX.Text>Admin Permission Management</RX.Text>
+        <CheckBox text={"console"} onCheckedChange={null} checkedByDefault={false}/>
+        <OkCancelButtonBar onOk={this.onOk} onCancel={this.onCancel} />
+      </RX.View>
+    );
+  }
+
+  private onOk = () => {
+    this.props.okCallback(this.state.selectedClientId);
+    RX.Modal.dismiss("addFromOnlinePlayersDialog");
+  }
+
+  private onCancel = () => {
+    RX.Modal.dismiss("addFromOnlinePlayersDialog");
+  }
+}

--- a/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
+++ b/src/tabs/serverAdmins/ManagePermissionsDialog.tsx
@@ -22,16 +22,21 @@ export class ManagePermissionsDialog extends RX.Component<ManagePermissionsDialo
   }
 
   public render() {
+    // TODO: change onCheckedChange to allow changing commands (maybe use a state?)
     return (
       <RX.View style={Styles.whiteBox}>
         <RX.Text>Admin Permission Management</RX.Text>
-        <CheckBox text={"Execute Console Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Execute Console Cheat Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Execute Console User Management Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Execute Console Server Management Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Execute Console Debug Commands"} onCheckedChange={undefined} checkedByDefault={false}/>
         <CheckBox text={"Install Modules"} onCheckedChange={undefined} checkedByDefault={false}/>
         <CheckBox text={"Create/Backup/Rename Games"} onCheckedChange={undefined} checkedByDefault={false}/>
         <CheckBox text={"Stop Games"} onCheckedChange={undefined} checkedByDefault={false}/>
         <CheckBox text={"Delete Games"} onCheckedChange={undefined} checkedByDefault={false}/>
         <CheckBox text={"Change Settings"} onCheckedChange={undefined} checkedByDefault={false}/>
         <CheckBox text={"User Management"} onCheckedChange={undefined} checkedByDefault={false}/>
+        <CheckBox text={"Admin Management"} onCheckedChange={undefined} checkedByDefault={false}/>
         <OkCancelButtonBar onOk={this.onOk} onCancel={this.onCancel} />
       </RX.View>
     );

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -17,7 +17,21 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
     });
   }
 
-  public modifyPermission = (adminId: string, checked: boolean, permissionNumber: number) => {
+  public getPermissions = () => {
+    this.model.requestResource({
+      method: "GET",
+      resourcePath: ["serverAdminsPermissions"],
+    });
+  }
+
+  public getPermissionOfAdmin = (adminId: string) => {
+    this.model.requestResource({
+      method: "GET",
+      resourcePath: ["serverAdmins", adminId, "permissions"],
+    });
+  }
+
+  public modifyAdminPermission = (adminId: string, checked: boolean, permissionNumber: number) => {
     this.model.requestResource({
       data: undefined,
       method: "PATCH",

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -1,6 +1,6 @@
 import {TabController} from "../TabController";
-import {ServerAdminsTabState} from "./ServerAdminsTabState";
 import {AdminPermissions} from "./AdminPermissions";
+import {ServerAdminsTabState} from "./ServerAdminsTabState";
 
 export class ServerAdminsTabController extends TabController<ServerAdminsTabState> {
 
@@ -19,7 +19,6 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
   }
 
   public modifyAdminPermission = (adminId: string, newPermissions: AdminPermissions) => {
-    console.log(newPermissions);
     this.model.requestResource({
       data: newPermissions,
       method: "PATCH",

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -18,7 +18,11 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
   }
 
   public modifyPermission = (adminId: string, checked: boolean, permissionNumber: number) => {
-    return adminId + checked + permissionNumber;
+    this.model.requestResource({
+      data: undefined,
+      method: "PATCH",
+      resourcePath: ["serverAdmins", adminId, "permissions"],
+    });
   }
 
 }

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -8,20 +8,12 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
       method: "POST",
       resourcePath: ["serverAdmins", newAdminId],
     });
-    this.updatePermissions();
   }
 
   public removeAdmin = (adminId: string) => {
     this.model.requestResource({
       method: "DELETE",
       resourcePath: ["serverAdmins", adminId],
-    });
-  }
-
-  public updatePermissions = () => {
-    this.model.requestResource({
-      method: "GET",
-      resourcePath: ["serverAdminPermissions"],
     });
   }
 

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -1,5 +1,5 @@
 import {TabController} from "../TabController";
-import {ServerAdminsTabState} from "./ServerAdminsTabState";
+import {AdminPermissions, ServerAdminsTabState} from "./ServerAdminsTabState";
 
 export class ServerAdminsTabController extends TabController<ServerAdminsTabState> {
 
@@ -8,6 +8,7 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
       method: "POST",
       resourcePath: ["serverAdmins", newAdminId],
     });
+    this.updatePermissions();
   }
 
   public removeAdmin = (adminId: string) => {
@@ -17,23 +18,16 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
     });
   }
 
-  public getPermissions = () => {
+  public updatePermissions = () => {
     this.model.requestResource({
       method: "GET",
-      resourcePath: ["serverAdminsPermissions"],
+      resourcePath: ["serverAdminPermissions"],
     });
   }
 
-  public getPermissionOfAdmin = (adminId: string) => {
+  public modifyAdminPermission = (adminId: string, newPermissions: AdminPermissions) => {
     this.model.requestResource({
-      method: "GET",
-      resourcePath: ["serverAdmins", adminId, "permissions"],
-    });
-  }
-
-  public modifyAdminPermission = (adminId: string, checked: boolean, permissionNumber: number) => {
-    this.model.requestResource({
-      data: undefined,
+      data: newPermissions,
       method: "PATCH",
       resourcePath: ["serverAdmins", adminId, "permissions"],
     });

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -1,5 +1,6 @@
 import {TabController} from "../TabController";
-import {AdminPermissions, ServerAdminsTabState} from "./ServerAdminsTabState";
+import {ServerAdminsTabState} from "./ServerAdminsTabState";
+import {AdminPermissions} from "./AdminPermissions";
 
 export class ServerAdminsTabController extends TabController<ServerAdminsTabState> {
 
@@ -18,6 +19,7 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
   }
 
   public modifyAdminPermission = (adminId: string, newPermissions: AdminPermissions) => {
+    console.log(newPermissions);
     this.model.requestResource({
       data: newPermissions,
       method: "PATCH",

--- a/src/tabs/serverAdmins/ServerAdminsTabController.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabController.tsx
@@ -17,4 +17,8 @@ export class ServerAdminsTabController extends TabController<ServerAdminsTabStat
     });
   }
 
+  public modifyPermission = (adminId: string, checked: boolean, permissionNumber: number) => {
+    return adminId + checked + permissionNumber;
+  }
+
 }

--- a/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
@@ -41,6 +41,7 @@ export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdmin
     } else if (ResourcePathUtil.equals(resourcePath, ["serverAdminPermissions"])) {
       this.adminPermissions = data as AdminPermissions[];
     }
+    console.log(this.adminPermissions);
     this.update({
       admins: this.adminIds.map((adminId) => ({
         id: adminId,

--- a/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
@@ -5,12 +5,13 @@ import {ResourcePath, ResourcePathUtil} from "../../io/ResourcePath";
 import {ResourceSubscriberTabModel} from "../ResourceSubscriberTabModel";
 import {TabController} from "../TabController";
 import {ServerAdminsTabController} from "./ServerAdminsTabController";
-import {ServerAdminsTabState} from "./ServerAdminsTabState";
+import {AdminPermissions, ServerAdminsTabState} from "./ServerAdminsTabState";
 
 export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdminsTabState> {
 
   private adminIds: string[] = [];
   private onlinePlayers: OnlinePlayerMetadata[] = [];
+  private adminPermissions: AdminPermissions[] = [];
 
   public getName(): string {
     return "Admins";
@@ -20,11 +21,12 @@ export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdmin
     return [
       ["serverAdmins"],
       ["onlinePlayers"],
+      ["serverAdminPermissions"],
     ];
   }
 
   public getDefaultState(): ServerAdminsTabState {
-    return {admins: [], nonAdmins: []};
+    return {admins: [], nonAdmins: [], adminPermissions: []};
   }
 
   public initController(): TabController<ServerAdminsTabState> {
@@ -36,6 +38,8 @@ export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdmin
       this.adminIds = data as string[];
     } else if (ResourcePathUtil.equals(resourcePath, ["onlinePlayers"])) {
       this.onlinePlayers = data as OnlinePlayerMetadata[];
+    } else if (ResourcePathUtil.equals(resourcePath, ["serverAdminPermissions"])) {
+      this.adminPermissions = data as AdminPermissions[];
     }
     this.update({
       admins: this.adminIds.map((adminId) => ({
@@ -48,6 +52,7 @@ export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdmin
           id: onlinePlayer.id,
           name: onlinePlayer.name,
         })),
+      adminPermissions: this.adminPermissions,
     });
   }
 

--- a/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
@@ -2,8 +2,9 @@ import {OnlinePlayerMetadata} from "../../io/OnlinePlayerMetadata";
 import {ResourcePath, ResourcePathUtil} from "../../io/ResourcePath";
 import {ResourceSubscriberTabModel} from "../ResourceSubscriberTabModel";
 import {TabController} from "../TabController";
+import {AdminPermissions} from "./AdminPermissions";
 import {ServerAdminsTabController} from "./ServerAdminsTabController";
-import {AdminPermissions, ServerAdminsTabState} from "./ServerAdminsTabState";
+import {ServerAdminsTabState} from "./ServerAdminsTabState";
 
 export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdminsTabState> {
 

--- a/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabModel.tsx
@@ -1,5 +1,3 @@
-import {EngineStateMetadata} from "../../io/EngineStateMetadata";
-import {IncomingMessage} from "../../io/IncomingMessage";
 import {OnlinePlayerMetadata} from "../../io/OnlinePlayerMetadata";
 import {ResourcePath, ResourcePathUtil} from "../../io/ResourcePath";
 import {ResourceSubscriberTabModel} from "../ResourceSubscriberTabModel";
@@ -41,7 +39,6 @@ export class ServerAdminsTabModel extends ResourceSubscriberTabModel<ServerAdmin
     } else if (ResourcePathUtil.equals(resourcePath, ["serverAdminPermissions"])) {
       this.adminPermissions = data as AdminPermissions[];
     }
-    console.log(this.adminPermissions);
     this.update({
       admins: this.adminIds.map((adminId) => ({
         id: adminId,

--- a/src/tabs/serverAdmins/ServerAdminsTabState.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabState.tsx
@@ -1,24 +1,8 @@
+import {AdminPermissions} from "common/tabs/serverAdmins/AdminPermissions";
+
 export interface IdNamePair {
   id: string;
   name: string;
-}
-
-export interface Permissions {
-  consoleCheat: boolean;
-  consoleUserManagement: boolean;
-  consoleServerManagement: boolean;
-  consoleDebug: boolean;
-  installModules: boolean;
-  createBackupRenameGames: boolean;
-  deleteGames: boolean;
-  startStopGames: boolean;
-  changeSettings: boolean;
-  adminManagement: boolean;
-}
-
-export interface AdminPermissions {
-  id: string;
-  permissions: Permissions;
 }
 
 export interface ServerAdminsTabState {

--- a/src/tabs/serverAdmins/ServerAdminsTabState.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabState.tsx
@@ -3,8 +3,7 @@ export interface IdNamePair {
   name: string;
 }
 
-export interface AdminPermissions {
-  id: string;
+export interface Permissions {
   consoleCheat: boolean;
   consoleUserManagement: boolean;
   consoleServerManagement: boolean;
@@ -12,9 +11,14 @@ export interface AdminPermissions {
   installModules: boolean;
   createBackupRenameGames: boolean;
   deleteGames: boolean;
-  stopGames: boolean;
+  startStopGames: boolean;
   changeSettings: boolean;
   adminManagement: boolean;
+}
+
+export interface AdminPermissions {
+  id: string;
+  permissions: Permissions;
 }
 
 export interface ServerAdminsTabState {

--- a/src/tabs/serverAdmins/ServerAdminsTabState.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabState.tsx
@@ -3,7 +3,22 @@ export interface IdNamePair {
   name: string;
 }
 
+export interface AdminPermissions {
+  id: string;
+  consoleCheat: boolean;
+  consoleUserManagement: boolean;
+  consoleServerManagement: boolean;
+  consoleDebug: boolean;
+  installModules: boolean;
+  createBackupRenameGames: boolean;
+  deleteGames: boolean;
+  stopGames: boolean;
+  changeSettings: boolean;
+  adminManagement: boolean;
+}
+
 export interface ServerAdminsTabState {
   admins: IdNamePair[];
   nonAdmins: IdNamePair[];
+  adminPermissions: AdminPermissions[];
 }

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -1,6 +1,5 @@
 import RX = require("reactxp");
 import Styles = require("../../styles/main");
-import {isNull} from "util";
 import {AlertDialog} from "../../AlertDialog";
 import {TextPromptDialog} from "../../TextPromptDialog";
 import {TabView} from "../TabView";
@@ -65,6 +64,7 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 
   private getPermissionsOfAdmin(adminId: string): AdminPermissions {
     for (const permission of this.state.adminPermissions) {
+      console.log(JSON.stringify(permission));
       if (permission.id === adminId) {
         return permission;
       }

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -1,10 +1,10 @@
 import RX = require("reactxp");
 import Styles = require("../../styles/main");
-import {ManagePermissionsDialog} from "./ManagePermissionsDialog";
 import {AlertDialog} from "../../AlertDialog";
 import {TextPromptDialog} from "../../TextPromptDialog";
 import {TabView} from "../TabView";
 import {AddFromOnlinePlayersDialog} from "./AddFromOnlinePlayersDialog";
+import {ManagePermissionsDialog} from "./ManagePermissionsDialog";
 import {ServerAdminsTabController} from "./ServerAdminsTabController";
 import {IdNamePair, ServerAdminsTabState} from "./ServerAdminsTabState";
 

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -65,7 +65,7 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 
   private getPermissionsOfAdmin(adminId: string): AdminPermissions {
     for (const permission of this.state.adminPermissions) {
-      if (permission.key === adminId) {
+      if (permission.id === adminId) {
         return permission;
       }
     }

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -4,10 +4,10 @@ import {AlertDialog} from "../../AlertDialog";
 import {TextPromptDialog} from "../../TextPromptDialog";
 import {TabView} from "../TabView";
 import {AddFromOnlinePlayersDialog} from "./AddFromOnlinePlayersDialog";
+import {AdminPermissions} from "./AdminPermissions";
 import {ManagePermissionsDialog} from "./ManagePermissionsDialog";
 import {ServerAdminsTabController} from "./ServerAdminsTabController";
 import {IdNamePair, ServerAdminsTabState} from "./ServerAdminsTabState";
-import {AdminPermissions} from "./AdminPermissions";
 
 export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -1,12 +1,13 @@
 import RX = require("reactxp");
 import Styles = require("../../styles/main");
+import {isNull} from "util";
 import {AlertDialog} from "../../AlertDialog";
 import {TextPromptDialog} from "../../TextPromptDialog";
 import {TabView} from "../TabView";
 import {AddFromOnlinePlayersDialog} from "./AddFromOnlinePlayersDialog";
 import {ManagePermissionsDialog} from "./ManagePermissionsDialog";
 import {ServerAdminsTabController} from "./ServerAdminsTabController";
-import {IdNamePair, ServerAdminsTabState} from "./ServerAdminsTabState";
+import {AdminPermissions, IdNamePair, ServerAdminsTabState} from "./ServerAdminsTabState";
 
 export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 
@@ -48,7 +49,8 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
   }
 
   private renderAdmin = (controller: ServerAdminsTabController) => (admin: IdNamePair) => {
-    const showManagePermission = () => ManagePermissionsDialog.show(controller.addAdmin);
+    const showManagePermission = () =>
+      ManagePermissionsDialog.show(admin.id, controller.modifyAdminPermission, this.getPermissionsOfAdmin(admin.id));
     return (
       <RX.View key={admin.id} style={Styles.flex.row}>
         <RX.View>
@@ -59,6 +61,15 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
         <RX.Button style={Styles.cancelButton} onPress={() => controller.removeAdmin(admin.id)}><RX.Text>Remove</RX.Text></RX.Button>
       </RX.View>
     );
+  }
+
+  private getPermissionsOfAdmin(adminId: string): AdminPermissions {
+    for (const permission of this.state.adminPermissions) {
+      if (permission.id === adminId) {
+        return permission;
+      }
+    }
+    return null;
   }
 
 }

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -6,7 +6,8 @@ import {TabView} from "../TabView";
 import {AddFromOnlinePlayersDialog} from "./AddFromOnlinePlayersDialog";
 import {ManagePermissionsDialog} from "./ManagePermissionsDialog";
 import {ServerAdminsTabController} from "./ServerAdminsTabController";
-import {AdminPermissions, IdNamePair, ServerAdminsTabState} from "./ServerAdminsTabState";
+import {IdNamePair, ServerAdminsTabState} from "./ServerAdminsTabState";
+import {AdminPermissions} from "./AdminPermissions";
 
 export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 
@@ -64,7 +65,7 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 
   private getPermissionsOfAdmin(adminId: string): AdminPermissions {
     for (const permission of this.state.adminPermissions) {
-      if (permission.id === adminId) {
+      if (permission.key === adminId) {
         return permission;
       }
     }

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -1,7 +1,7 @@
 import RX = require("reactxp");
 import Styles = require("../../styles/main");
+import {ManagePermissionsDialog} from "./ManagePermissionsDialog";
 import {AlertDialog} from "../../AlertDialog";
-import {OkCancelButtonBar} from "../../OkCancelButtonBar";
 import {TextPromptDialog} from "../../TextPromptDialog";
 import {TabView} from "../TabView";
 import {AddFromOnlinePlayersDialog} from "./AddFromOnlinePlayersDialog";
@@ -48,12 +48,14 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
   }
 
   private renderAdmin = (controller: ServerAdminsTabController) => (admin: IdNamePair) => {
+    const showManagePermission = () => ManagePermissionsDialog.show(controller.addAdmin);
     return (
       <RX.View key={admin.id} style={Styles.flex.row}>
         <RX.View>
           <RX.Text>{admin.id}</RX.Text>
           <RX.Text>{admin.name !== null ? "Currently online as " + admin.name : "Currently offline"}</RX.Text>
         </RX.View>
+        <RX.Button style={Styles.okButton} onPress={showManagePermission}><RX.Text>Manage Permissions</RX.Text></RX.Button>
         <RX.Button style={Styles.cancelButton} onPress={() => controller.removeAdmin(admin.id)}><RX.Text>Remove</RX.Text></RX.Button>
       </RX.View>
     );

--- a/src/tabs/serverAdmins/ServerAdminsTabView.tsx
+++ b/src/tabs/serverAdmins/ServerAdminsTabView.tsx
@@ -64,7 +64,6 @@ export class ServerAdminsTabView extends TabView<ServerAdminsTabState> {
 
   private getPermissionsOfAdmin(adminId: string): AdminPermissions {
     for (const permission of this.state.adminPermissions) {
-      console.log(JSON.stringify(permission));
       if (permission.id === adminId) {
         return permission;
       }


### PR DESCRIPTION
Add a frontend for Admin Permissions. To test, start up the backend and connect to it through the frontend, and look at the admins tab where there should be a new button for managing permissions.

There are a few bugs though:
* attempting to manage permissions immediately after the first admin is connected causes the frontend to give an error where none of the permissions are checked, but refreshing fixes it.
* after adding permissions of console commands in the frontend, taking them away only takes them away in the backend. In the frontend, it is still possible to execute the commands 