### PR TITLE
Change the console to only execute server commands

### DIFF
--- a/src/tabs/console/ConsoleTabModel.tsx
+++ b/src/tabs/console/ConsoleTabModel.tsx
@@ -15,11 +15,12 @@ export class ConsoleTabModel extends ResourceSubscriberTabModel<ConsoleTabState>
   public getSubscribedResourcePaths(): ResourcePath[] {
     return [
       ["console"],
+      ["consoleHelp"],
     ];
   }
 
   public getDefaultState(): ConsoleTabState {
-    return {messages: [], commandToSend: "Type a command here...", commands: []};
+    return {messages: [], commandToSend: "Type a command here...", commands: [], filteredHelpText: ""};
   }
 
   public initController(): TabController<ConsoleTabState> {
@@ -29,6 +30,8 @@ export class ConsoleTabModel extends ResourceSubscriberTabModel<ConsoleTabState>
   public onResourceUpdated(resourcePath: ResourcePath, data: any): void {
     if (ResourcePathUtil.equals(resourcePath, ["console"])) {
       this.update({commands: data as string[]});
+    } else if (ResourcePathUtil.equals(resourcePath, ["consoleHelp"])) {
+      this.update({filteredHelpText: data as string});
     }
   }
 

--- a/src/tabs/console/ConsoleTabState.tsx
+++ b/src/tabs/console/ConsoleTabState.tsx
@@ -7,4 +7,5 @@ export interface ConsoleTabState {
   messages?: Message[];
   commandToSend?: string;
   commands?: string[];
+  filteredHelpText?: string;
 }

--- a/src/tabs/console/ConsoleTabView.tsx
+++ b/src/tabs/console/ConsoleTabView.tsx
@@ -6,7 +6,7 @@ import Styles = require("../../styles/main");
 import {TabView} from "../TabView";
 import {ConsoleAutocomplete} from "./ConsoleAutocomplete";
 import {ConsoleTabController} from "./ConsoleTabController";
-import {ConsoleTabState} from "./ConsoleTabState";
+import {ConsoleTabState, Message} from "./ConsoleTabState";
 
 interface MessagePart {
   text: string;
@@ -36,10 +36,24 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
             onChangeText={this.onChangeValue}
             autoFocus={true}
             onKeyPress={(event) =>  {this.handleKeypress(event, controller); }}/>
-          <RX.Button style={Styles.okButton} onPress={controller.execute}><RX.Text>Execute</RX.Text></RX.Button>
+          <RX.Button style={Styles.okButton} onPress={() => this.onCommandEntered(this.state.commandToSend, controller)}>
+            <RX.Text>Execute</RX.Text>
+          </RX.Button>
         </RX.View>
       </RX.ScrollView>
     );
+  }
+
+  private onCommandEntered(command: string, controller: ConsoleTabController) {
+    command = command.indexOf(" ") === -1 ? command : command.substr(0, command.indexOf(" "));
+    if (command === "help") {
+      const addedMessage: Message[] = [{type: "CONSOLE", message: this.state.filteredHelpText}];
+      this.props.model.update({messages: this.state.messages.concat(addedMessage), commandToSend: ""});
+    } else if (this.state.commands.indexOf(command) !== -1) {
+      controller.execute();
+    } else {
+      this.props.model.update({commandToSend: "enter valid command"});
+    }
   }
 
   private onChangeValue = (newValue: string) => {
@@ -98,7 +112,7 @@ export class ConsoleTabView extends TabView<ConsoleTabState> {
     if (event.keyCode === 9) {
       this.autoComplete(this.state.commandToSend);
     } else if (event.keyCode === 13) {
-      controller.execute();
+      this.onCommandEntered(this.state.commandToSend, controller);
     }
   }
 


### PR DESCRIPTION
This PR makes it so that the console can only execute commands if the `runOnServer` boolean for each command is set to true. If the command is not valid, then the console doesn't even try to execute it. Also, the help text is changed to reflect these differences.